### PR TITLE
Added MainPage implementation example with different map views

### DIFF
--- a/src/XamarinLatinoMaps/XamarinLatinoMaps/MainPage.xaml
+++ b/src/XamarinLatinoMaps/XamarinLatinoMaps/MainPage.xaml
@@ -4,5 +4,12 @@
              xmlns:local="clr-namespace:XamarinLatinoMaps"
              xmlns:maps="clr-namespace:Xamarin.Forms.Maps;assembly=Xamarin.Forms.Maps"
              x:Class="XamarinLatinoMaps.MainPage">
-    <maps:Map HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" />
+    <StackLayout>
+        <maps:Map x:Name="MapView" HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" />
+        <StackLayout Spacing="15" Padding="20" Orientation="Horizontal" VerticalOptions="End" HorizontalOptions="FillAndExpand">
+            <Button HorizontalOptions="EndAndExpand" VerticalOptions="Center" HeightRequest="50" Text="Street" Clicked="Street_OnClicked" />
+            <Button HorizontalOptions="Center" VerticalOptions="Center" HeightRequest="50" Text="Hybrid" Clicked="Hybrid_OnClicked" />
+            <Button HorizontalOptions="StartAndExpand" VerticalOptions="Center" HeightRequest="50" Text="Satellite" Clicked="Satellite_OnClicked" />
+        </StackLayout>
+    </StackLayout>
 </ContentPage>

--- a/src/XamarinLatinoMaps/XamarinLatinoMaps/MainPage.xaml.cs
+++ b/src/XamarinLatinoMaps/XamarinLatinoMaps/MainPage.xaml.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xamarin.Forms;
+using Xamarin.Forms.Maps;
 
 namespace XamarinLatinoMaps
 {
@@ -12,6 +9,25 @@ namespace XamarinLatinoMaps
 		public MainPage()
 		{
 			InitializeComponent();
-		}
+		    MapView.MoveToRegion(
+		        MapSpan.FromCenterAndRadius(
+		            new Position(37, -122), Distance.FromMiles(1)));
+        }
+
+	    private void Street_OnClicked(object sender, EventArgs e)
+	    {
+	        MapView.MapType = MapType.Street;
+	    }
+
+
+	    private void Hybrid_OnClicked(object sender, EventArgs e)
+	    {
+	        MapView.MapType = MapType.Hybrid;
+	    }
+
+	    private void Satellite_OnClicked(object sender, EventArgs e)
+	    {
+	        MapView.MapType = MapType.Satellite;
+	    }
 	}
 }


### PR DESCRIPTION
# What's new?
We have added an implementation example in the project Xamarin Forms. This includes three buttons that change the map view between the different map types on the map: Street, Hybrid, and Satellite.

## Visual Aids
![screen shot 2018-03-19 at 12 26 46 am](https://user-images.githubusercontent.com/8483978/37581717-64b77860-2b0f-11e8-990a-bda2db05ca84.png)

![screenshot_1521440826](https://user-images.githubusercontent.com/8483978/37581719-681b04e0-2b0f-11e8-9991-b44c5e89682f.png)

![screen shot 2018-03-19 at 12 31 29 am](https://user-images.githubusercontent.com/8483978/37581724-6ce24ee8-2b0f-11e8-98ac-ea7a9212af19.png)
